### PR TITLE
Only build macos wheels for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
               | pyp 'json.dumps({"only": x, "os": "ubuntu-latest"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform linux --archs aarch64 mypy \
               | pyp 'json.dumps({"only": x, "os": "ubuntu-24.04-arm"})' \
-              && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos mypy \
+              && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform macos --archs arm64 mypy \
               | pyp 'json.dumps({"only": x, "os": "macos-latest"})' \
               && cibuildwheel --config-file=cibuildwheel.toml --print-build-identifiers --platform windows mypy \
               | pyp 'json.dumps({"only": x, "os": "windows-latest"})'


### PR DESCRIPTION
Drop support for macos x86_64.