### PR TITLE
Update cibuildwheels to 4.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Install cibuildwheel and pypyp
         run: |
-          pipx install cibuildwheel==4.1.1
+          pipx install cibuildwheel==4.2.0
           pipx install pypyp==1.3.0
       - id: set-matrix
         run: |
@@ -102,7 +102,7 @@ jobs:
         run: |
           pip install -U -r requirements.txt
           python scripts/modify_setup.py ${{ needs.generate_wheels_matrix.outputs.tag_version }}
-      - uses: pypa/cibuildwheel@v4.1.1
+      - uses: pypa/cibuildwheel@v4.2.0
         with:
           config-file: cibuildwheel.toml
           package-dir: mypy


### PR DESCRIPTION
https://github.com/pypa/cibuildwheel/releases/tag/v4.2.0